### PR TITLE
Oe extension

### DIFF
--- a/Apollo/ApolloExtra.lua
+++ b/Apollo/ApolloExtra.lua
@@ -1917,8 +1917,8 @@ if ModUtil ~= nil then
 			{
 				WeaponName = "ApolloShoutWeapon",
 				ProjectileProperty = "DamageLow",
-				BaseMin = 35,
-				BaseMax = 35,
+				BaseMin = 55,
+				BaseMax = 55,
 				DepthMult = DepthDamageMultiplier,
 				IdenticalMultiplier =
 				{
@@ -5185,7 +5185,7 @@ if ModUtil ~= nil then
 		function(baseFunc, victim, attacker, args)
 			local missRate = 0.4
 			if HeroHasTrait("MissChanceTrait") then
-				missRate = 0.65
+				missRate = 0.6
 			end
 			-- Enemies misses
 			if args and args.EffectName ~= "StyxPoison" and attacker and

--- a/Apollo/ApolloExtra.lua
+++ b/Apollo/ApolloExtra.lua
@@ -1917,8 +1917,8 @@ if ModUtil ~= nil then
 			{
 				WeaponName = "ApolloShoutWeapon",
 				ProjectileProperty = "DamageLow",
-				BaseMin = 55,
-				BaseMax = 55,
+				BaseMin = 35,
+				BaseMax = 35,
 				DepthMult = DepthDamageMultiplier,
 				IdenticalMultiplier =
 				{

--- a/Apollo/Text/en/HelpText.en.sjson
+++ b/Apollo/Text/en/HelpText.en.sjson
@@ -273,7 +273,7 @@
 		{
 			Id = "MissChanceTrait"
 			DisplayName = "Purest light"
-			Description = "Your {$Keywords.ApolloBlind} effects have a greater miss chance. \n {!Icons.Bullet}{#PropertyFormat}Miss chance: \Column 380 {#PreviousFormat}{#UpgradeFormat}65%"
+			Description = "Your {$Keywords.ApolloBlind} effects have a greater miss chance. \n {!Icons.Bullet}{#PropertyFormat}Miss chance: \Column 380 {#PreviousFormat}{#UpgradeFormat}60%"
 		}
 		{
 			Id = "ForceApolloBoonTrait"

--- a/Hestia/Text/en/HelpText.en.sjson
+++ b/Hestia/Text/en/HelpText.en.sjson
@@ -4,7 +4,7 @@
 		{
 			Id = "NPC_Hestia_01"
 			DisplayName = "Hestia"
-			Description = "Goddess of Hearth"
+			Description = "Goddess of the Hearth"
 		}		
 		{
 			Id = "HestiaFirstPickUp"
@@ -13,11 +13,11 @@
 		{
 			Id = "HestiaUpgrade"
 			DisplayName = "Hestia"
-			Description = "Goddess of Hearth"
+			Description = "Goddess of the Hearth"
 		}
 		{
 			Id = "HestiaUpgrades"
-			DisplayName = "Goddess of Hearth"
+			DisplayName = "Goddess of the Hearth"
 			Description = "The son of the god of the dead shall someday earn various Boons of Hestia."
 		}
 		{


### PR DESCRIPTION
Nerfed Legendary since it make more sense to have equal difference between normal blind % and legendary blind %.
40% vs 60% since the exact same calculation but in reverse. People can't complaint about that.